### PR TITLE
Private apps victoria

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,8 +27,7 @@ jobs:
       env:
         SPLUNK_COM_USERNAME: ${{ secrets.SPLUNK_COM_USERNAME }}
         SPLUNK_COM_PASSWORD: ${{ secrets.SPLUNK_COM_PASSWORD }}
-        STACK_NAME: ${{ secrets.STACK_NAME }}
-      run: make inspect-app
+      run: make inspect-app # this can be changed to inspect-app-victoria to vet an app intended to be installed on a victoria stack
 
     - uses: actions/upload-artifact@v2
       if: ${{ always() }}
@@ -42,7 +41,4 @@ jobs:
         SPLUNK_COM_PASSWORD: ${{ secrets.SPLUNK_COM_PASSWORD }}
         STACK_TOKEN: ${{ secrets.STACK_TOKEN }}
         STACK_NAME: ${{ secrets.STACK_NAME }}
-        ACS_URL: https://admin.splunk.com
-      run: make install-app
-
-
+      run: make install-app # this can be changed to install-app-victoria to install an app on a victoria stack

--- a/Makefile
+++ b/Makefile
@@ -7,9 +7,17 @@ generate-app-package:
 inspect-app:
 	./cloudCtl vet app-package.tar.gz --json-report-file=report.json
 
+inspect-app-victoria:
+	./cloudCtl vet app-package.tar.gz --json-report-file=report.json --victoria
+
 install-app:
 	./cloudCtl install ${STACK_NAME} app-package.tar.gz
+
+install-app-victoria:
+	./cloudCtl install ${STACK_NAME} app-package.tar.gz --victoria
 
 uninstall-app:
 	./cloudCtl uninstall ${STACK_NAME} testapp
 
+uninstall-app-victoria:
+	./cloudCtl uninstall ${STACK_NAME} testapp --victoria

--- a/README.md
+++ b/README.md
@@ -11,9 +11,10 @@ The pipeline primarily consists of 4 steps:
 
 The steps of the pipeline can be found [here](https://github.com/splunk/acs-privateapps-demo/blob/main/.github/workflows/main.yml).
 
+Note that a few steps (app-vetting and app-installation) have Victoria and Classic variations in the Makefile.
+
 ## Setting up the environment
 The environment needs to be configured with a few variables. If leveraging this from a Github repository using Github Actions workflows, the variables will need to be set up as [secrets](https://docs.github.com/en/actions/security-guides/encrypted-secrets). If running this locally, these values simply need to be set as environment variables:
 * SPLUNK_COM_USERNAME / SPLUNK_COM_PASSWORD - the [splunk.com](https://login.splunk.com/) credentials to use for authentication to perform app inspection.
 * STACK_NAME - the name of the Splunk Cloud stack where you want to install/update the app package on.
 * STACK_TOKEN - the [jwt token](https://docs.splunk.com/Documentation/Splunk/latest/Security/Setupauthenticationwithtokens) created on the stack.
-* ACS_URL - `https://admin.splunk.com`

--- a/src/appinspect/client.go
+++ b/src/appinspect/client.go
@@ -127,11 +127,19 @@ type SubmitResult struct {
 }
 
 // Submit an app-package for inspection
-func (c *Client) Submit(filename string, file io.Reader) (*SubmitResult, error) {
+func (c *Client) Submit(filename string, file io.Reader, isVictoria bool) (*SubmitResult, error) {
 
-	formdata := url.Values{
-		"included_tags": []string{"private_app"},
+	var formdata url.Values
+	if isVictoria {
+		formdata = url.Values{
+			"included_tags": []string{"cloud,self-service"},
+		}
+	} else {
+		formdata = url.Values{
+			"included_tags": []string{"private_app"},
+		}
 	}
+
 	resp, err := c.R().SetAuthToken(c.token).SetFormDataFromValues(formdata).
 		SetFileReader("app_package", filename, file).SetResult(&SubmitResult{}).Post("/validate")
 	if err != nil {

--- a/src/cmd/get.go
+++ b/src/cmd/get.go
@@ -26,7 +26,8 @@ type get struct {
 	StackName  string `kong:"arg,help='the splunk cloud stack'"`
 	AppName    string `kong:"arg,optional,help='the app'"`
 	StackToken string `kong:"env='STACK_TOKEN',help='the stack sc_admin jwt token'"`
-	AcsURL     string `kong:"env='ACS_URL',help='the acs url',default:'http://localhost:8443/'"`
+	AcsURL     string `kong:"env='ACS_URL',help='the acs url',default='https://admin.splunk.com'"`
+	Victoria   bool   `kong:"help='whether the stack is a Victora stack'"`
 }
 
 func (g *get) Run(c *context) error {
@@ -38,7 +39,12 @@ func (g *get) Run(c *context) error {
 		fmt.Println("")
 	}
 
-	cli := acs.NewWithURL(g.AcsURL, g.StackToken)
+	var cli acs.Client
+	if g.Victoria {
+		cli = acs.NewVictoriaWithURL(g.AcsURL, g.StackToken)
+	} else {
+		cli = acs.NewClassicWithURL(g.AcsURL, g.StackToken)
+	}
 
 	var object interface{}
 	var err error
@@ -52,7 +58,6 @@ func (g *get) Run(c *context) error {
 		if err != nil {
 			return err
 		}
-
 	}
 
 	if data, e := json.MarshalIndent(object, "", "    "); e == nil {

--- a/src/cmd/vet.go
+++ b/src/cmd/vet.go
@@ -30,6 +30,7 @@ type vet struct {
 	SplunkComUsername string `kong:"env='SPLUNK_COM_USERNAME',help='the splunkbase username'"`
 	SplunkComPassword string `kong:"env='SPLUNK_COM_PASSWORD',help='the splunkbase password'"`
 	JSONReportFile    string `kong:"help='the file to write the inspection report in json format',type='path'"`
+	Victoria          bool   `kong:"help='whether the stack is a Victora stack'"`
 }
 
 func (v *vet) Run(c *context) error {
@@ -54,7 +55,7 @@ func (v *vet) Run(c *context) error {
 	if err != nil {
 		return err
 	}
-	submitRes, err := cli.Submit(filepath.Base(v.PackageFilePath), bytes.NewReader(pf))
+	submitRes, err := cli.Submit(filepath.Base(v.PackageFilePath), bytes.NewReader(pf), v.Victoria)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Victoria support for private app management

this introduces a new `--victoria` option to most `cloudCtl` commands that indicates that the user is interacting with a Victoria stack