### PR TITLE
Add support html report, status by app hash, and new tags

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/alecthomas/kong v0.2.12
 	github.com/go-resty/resty/v2 v2.4.0
 	github.com/howeyc/gopass v0.0.0-20190910152052-7cb4b85ec19c // indirect
+	github.com/jarcoal/httpmock v1.1.0 // indirect
 	github.com/segmentio/go-prompt v1.2.0
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad // indirect

--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,8 @@ github.com/go-resty/resty/v2 v2.4.0/go.mod h1:B88+xCTEwvfD94NOuE6GS1wMlnoKNY8eEi
 github.com/hinshun/vt10x v0.0.0-20180616224451-1954e6464174/go.mod h1:DqJ97dSdRW1W22yXSB90986pcOyQ7r45iio1KN2ez1A=
 github.com/howeyc/gopass v0.0.0-20190910152052-7cb4b85ec19c h1:aY2hhxLhjEAbfXOx2nRJxCXezC6CO2V/yN+OCr1srtk=
 github.com/howeyc/gopass v0.0.0-20190910152052-7cb4b85ec19c/go.mod h1:lADxMC39cJJqL93Duh1xhAs4I2Zs8mKS89XWXFGp9cs=
+github.com/jarcoal/httpmock v1.1.0 h1:F47ChZj1Y2zFsCXxNkBPwNNKnAyOATcdQibk0qEdVCE=
+github.com/jarcoal/httpmock v1.1.0/go.mod h1:ATjnClrvW/3tijVmpL/va5Z3aAyGvqU3gCT8nX0Txik=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 h1:Z9n2FFNUXsshfwJMBgNA0RU6/i7WVaAegv3PtuIHPMs=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:CzGEWj7cYgsdH8dAjBGEr58BoE7ScuLd+fwFZ44+/x8=
 github.com/kr/pty v1.1.4/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=

--- a/src/appinspect/client.go
+++ b/src/appinspect/client.go
@@ -394,7 +394,7 @@ func addIdToRequest(r *resty.Request, id interface{}) (*addIdResult, error) {
 			r.SetQueryParam("included_tags", strings.Join(value.IncludeTags, ","))
 		}
 	default:
-		return nil, fmt.Errorf("can't conver id to proper format: %s", id)
+		return nil, fmt.Errorf("can't add id to request: unknown type %q", id)
 	}
 	return result, nil
 }

--- a/src/appinspect/client_test.go
+++ b/src/appinspect/client_test.go
@@ -1,8 +1,10 @@
 package appinspect
 
-import "testing"
-import "github.com/jarcoal/httpmock"
-import "github.com/stretchr/testify/assert"
+import (
+	"github.com/jarcoal/httpmock"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
 
 const TESTING_URL = "http://foo-bar"
 
@@ -22,9 +24,15 @@ func TestStatusById(t *testing.T) {
 		RequestID: requestId,
 	})
 	httpmock.RegisterResponder("GET", TESTING_URL+"/validate/status/"+requestId, responder)
-
 	status, _ := client.Status(requestId)
 	assert.Equal(status.RequestID, requestId)
+
+	responder, _ = httpmock.NewJsonResponder(401, nil)
+	httpmock.RegisterResponder("GET", TESTING_URL+"/validate/status/"+requestId, responder)
+	status, err := client.Status(requestId)
+	assert.Error(err)
+	assert.Equal(status.RequestID, requestId)
+	assert.Equal(status.StatusCode, 401)
 }
 
 func TestStatusByHash(t *testing.T) {
@@ -36,9 +44,15 @@ func TestStatusByHash(t *testing.T) {
 		RequestID: requestId,
 	})
 	httpmock.RegisterResponder("GET", TESTING_URL+"/validate/status/Baz?included_tags=test-tag", responder)
-
 	status, _ := client.Status(ShaId{"Baz", []string{"test-tag"}})
 	assert.Equal(status.RequestID, requestId)
+
+	responder, _ = httpmock.NewJsonResponder(402, nil)
+	httpmock.RegisterResponder("GET", TESTING_URL+"/validate/status/"+requestId, responder)
+	status, err := client.Status(requestId)
+	assert.Error(err)
+	assert.Equal(status.RequestID, requestId)
+	assert.Equal(status.StatusCode, 402)
 }
 
 func TestReportJSON(t *testing.T) {
@@ -50,9 +64,14 @@ func TestReportJSON(t *testing.T) {
 		RequestID: requestId,
 	})
 	httpmock.RegisterResponder("GET", TESTING_URL+"/report/"+requestId, responder)
-
 	report, _ := client.ReportJSON(requestId)
 	assert.Equal(report.RequestID, requestId)
+
+	responder, _ = httpmock.NewJsonResponder(401, nil)
+	httpmock.RegisterResponder("GET", TESTING_URL+"/report/"+requestId, responder)
+	report, err := client.ReportJSON(requestId)
+	assert.Error(err)
+	assert.Nil(report)
 }
 
 func TestReportHTML(t *testing.T) {
@@ -61,10 +80,36 @@ func TestReportHTML(t *testing.T) {
 	client := getClient()
 
 	response := []byte("<i>Hello test</i>")
-
 	httpmock.RegisterResponder("GET", TESTING_URL+"/report/"+requestId, httpmock.NewBytesResponder(
 		200, response))
-
 	report, _ := client.ReportHTML(requestId)
 	assert.Equal(report, response)
+
+	httpmock.RegisterResponder("GET", TESTING_URL+"/report/"+requestId, httpmock.NewBytesResponder(
+		402, nil))
+	report, err := client.ReportHTML(requestId)
+	assert.Error(err)
+	assert.Nil(report)
+}
+
+func TestAddIdToRequest(t *testing.T) {
+	assert := assert.New(t)
+	request := getClient().Client.R()
+
+	request.URL = "/foo/"
+	result, err := addIdToRequest(request, "bar")
+	assert.Nil(err)
+	assert.Empty(result.Sha)
+	assert.Equal("bar", result.RequestID)
+	assert.Equal("/foo/bar", request.URL)
+
+	request.URL = "/foo/"
+	result, err = addIdToRequest(request, ShaId{"baz", []string{"test-tag"}})
+	assert.Nil(err)
+	assert.Empty(result.RequestID)
+	assert.Equal("baz", result.Sha)
+	assert.Equal("/foo/baz", request.URL)
+
+	_, err = addIdToRequest(request, 1)
+	assert.Error(err)
 }

--- a/src/appinspect/client_test.go
+++ b/src/appinspect/client_test.go
@@ -1,0 +1,70 @@
+package appinspect
+
+import "testing"
+import "github.com/jarcoal/httpmock"
+import "github.com/stretchr/testify/assert"
+
+const TESTING_URL = "http://foo-bar"
+
+func getClient() *Client {
+	client := New()
+	client.Client.SetHostURL(TESTING_URL)
+	httpmock.ActivateNonDefault(client.GetClient())
+	return client
+}
+
+func TestStatusById(t *testing.T) {
+	assert := assert.New(t)
+	requestId := "Foo"
+	client := getClient()
+
+	responder, _ := httpmock.NewJsonResponder(200, StatusResult{
+		RequestID: requestId,
+	})
+	httpmock.RegisterResponder("GET", TESTING_URL+"/validate/status/"+requestId, responder)
+
+	status, _ := client.Status(requestId)
+	assert.Equal(status.RequestID, requestId)
+}
+
+func TestStatusByHash(t *testing.T) {
+	assert := assert.New(t)
+	requestId := "Foo"
+	client := getClient()
+
+	responder, _ := httpmock.NewJsonResponder(200, StatusResult{
+		RequestID: requestId,
+	})
+	httpmock.RegisterResponder("GET", TESTING_URL+"/validate/status/Baz?included_tags=test-tag", responder)
+
+	status, _ := client.Status(ShaId{"Baz", []string{"test-tag"}})
+	assert.Equal(status.RequestID, requestId)
+}
+
+func TestReportJSON(t *testing.T) {
+	assert := assert.New(t)
+	requestId := "Bar"
+	client := getClient()
+
+	responder, _ := httpmock.NewJsonResponder(200, ReportJSONResult{
+		RequestID: requestId,
+	})
+	httpmock.RegisterResponder("GET", TESTING_URL+"/report/"+requestId, responder)
+
+	report, _ := client.ReportJSON(requestId)
+	assert.Equal(report.RequestID, requestId)
+}
+
+func TestReportHTML(t *testing.T) {
+	assert := assert.New(t)
+	requestId := "Baz"
+	client := getClient()
+
+	response := []byte("<i>Hello test</i>")
+
+	httpmock.RegisterResponder("GET", TESTING_URL+"/report/"+requestId, httpmock.NewBytesResponder(
+		200, response))
+
+	report, _ := client.ReportHTML(requestId)
+	assert.Equal(report, response)
+}


### PR DESCRIPTION
Current client supports fetching a vetting status by request id and getting report in JSON format.

A3 supports fetching status not only by request id, but also by app hash, with optional tags. Fetching HTML version of vetting report is possible as well.

This PR adds support html report, status by app hash, and new tags