### PR TITLE
Updating GitHub Actions defs to use current versions

### DIFF
--- a/.github/workflows/acs-demo.yml
+++ b/.github/workflows/acs-demo.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       
     - name: Generate Package
       run: make generate-app-package

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: self-hosted
     steps:
     - name: Checkout Repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Set up Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
         go-version: 1.15
 
@@ -29,7 +29,7 @@ jobs:
         SPLUNK_COM_PASSWORD: ${{ secrets.SPLUNK_COM_PASSWORD }}
       run: make inspect-app-victoria # this can be changed to inspect-app to vet an app intended to be installed on a classic stack
 
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       if: ${{ always() }}
       with:
         name: report.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@3
 
     - name: Bump version and push tag
       run: |


### PR DESCRIPTION
The v2 actions throw errors on invocation and don't change functionality in the jump to v3.